### PR TITLE
Update tests

### DIFF
--- a/tests/testthat/test-ggplot2_colour_layer.R
+++ b/tests/testthat/test-ggplot2_colour_layer.R
@@ -1,8 +1,8 @@
 test_that("continuous colour scales are created", {
   for (palette in academic_colour_palette_names()) {
     function_value <- scale_colour_academic_c(palette)
-    colours <- academic_colour_palette(palette)
-    expected_value <- ggplot2::scale_colour_gradientn(colours = colours)
+    palette <- academic_colour_palette(palette)
+    expected_value <- ggplot2::scale_colour_gradientn(colours = palette)
     expect_equal(
       function_value,
       expected_value
@@ -21,8 +21,12 @@ test_that("discrete colours scales are created", {
       scale_name = paste0("AcademicTheme: ", palette_name)
     )
     expect_equal(
-      function_value,
-      expected_value
+      .subset2(function_value, "palette"),
+      .subset2(expected_value, "palette")
+    )
+    expect_equal(
+      function_value$aesthetics,
+      expected_value$aesthetics,
     )
   }
 })

--- a/tests/testthat/test-ggplot2_fill_layer.R
+++ b/tests/testthat/test-ggplot2_fill_layer.R
@@ -1,8 +1,8 @@
 test_that("continuous fill scales are created", {
   for (palette in academic_colour_palette_names()) {
     function_value <- scale_fill_academic_c(palette)
-    colours <- academic_colour_palette(palette)
-    expected_value <- ggplot2::scale_fill_gradientn(colours = colours)
+    palette <- academic_colour_palette(palette)
+    expected_value <- ggplot2::scale_fill_gradientn(colours = palette)
     expect_equal(
       function_value,
       expected_value
@@ -21,8 +21,12 @@ test_that("discrete fill scales are created", {
       scale_name = paste0("AcademicTheme: ", palette_name)
     )
     expect_equal(
-      function_value,
-      expected_value
+      .subset2(function_value, "palette"),
+      .subset2(expected_value, "palette")
+    )
+    expect_equal(
+      function_value$aesthetics,
+      expected_value$aesthetics,
     )
   }
 })


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospsective ggplot2 3.5.0 would break AcademicThemes' tests.

This PR updates the tests to deal with the incoming changes to ggplot2. The current tests rely on the equality of scales, which no longer completely holds due to changes in ggplot2's internals.

To test the code chagnes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```
The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help AcademicThemes be prepared for the new release.

